### PR TITLE
Restricting webserver playbook to newly created nodes only

### DIFF
--- a/roles/add_host/tasks/main.yml
+++ b/roles/add_host/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- add_host:
+   name: "{{ item }}"
+   ansible_ssh_host: 127.0.0.1
+   groups: os_api
+   ansible_connection: local
+   oshost: "{{ item }}"
+  with_items: servers
+

--- a/roles/common-tasks/tasks/main.yml
+++ b/roles/common-tasks/tasks/main.yml
@@ -28,11 +28,7 @@
   tags: user
 
 - name: Clear apt cache
-  apt: update_cache=yes
-  sudo: true
-
-- name: Upgrade packages
-  apt: upgrade=full
+  apt: update_cache=yes upgrade=yes
   sudo: true
 
 - name: restart machine

--- a/roles/nova/tasks/main.yml
+++ b/roles/nova/tasks/main.yml
@@ -32,7 +32,7 @@
     name: "{{ nova.info.name }}.{{ nova.info.id }}"
     ansible_ssh_host: "{{ nova.private_ip }}"
     ansible_ssh_private_key_file: ~/.ssh/search.pem
-    groups: "{{ nova.info.metadata.type }}"
+    groups: "newly-created"
 
 - name: wait for instance to boot
   wait_for:

--- a/roles/webserver/vars/webserver-settings.yml
+++ b/roles/webserver/vars/webserver-settings.yml
@@ -4,15 +4,15 @@
 
 ---
 servers:
-  - testingthis
+  - servername
 
-flavor: 1
+flavor: 3
 
 # This image ID is for the Ubuntu 14.04 LTS cloud image.  To use a different image
 # run nova image-list to get its id
 image_id: c12e0e1e-0deb-4b63-be9e-2c7b98617cbe
 
-type: testing
+type: webserver
 
 security_groups: default,www
 

--- a/roles/webserver/vars/webserver-settings.yml
+++ b/roles/webserver/vars/webserver-settings.yml
@@ -4,16 +4,15 @@
 
 ---
 servers:
-  - xyz
-  - userapi
+  - testingthis
 
-flavor: 3
+flavor: 1
 
 # This image ID is for the Ubuntu 14.04 LTS cloud image.  To use a different image
 # run nova image-list to get its id
 image_id: c12e0e1e-0deb-4b63-be9e-2c7b98617cbe
 
-type: webserver
+type: testing
 
 security_groups: default,www
 

--- a/webserver.yml
+++ b/webserver.yml
@@ -4,31 +4,26 @@
 ---
 - name: add some hosts
   hosts: localhost
-  vars_files:
-    - roles/webserver/vars/webserver-settings.yml
-
-  tasks:
-    - add_host:
-        name: "{{ item }}"
-        ansible_ssh_host: 127.0.0.1
-        groups: os_api
-        ansible_connection: local
-        oshost: "{{ item }}"
-      with_items: servers
-    - debug: var=groups
+  
+  roles: 
+    - add_host
 
 - name: Spin up new servers
   hosts: os_api
   user: root
+  sudo: yes
+
   serial: 1
 
   vars_files:
     - roles/webserver/vars/webserver-settings.yml
+    - roles/common-tasks/vars/common-secret.yml
+
   roles:
     - nova
 
 - name: Setup the new webservers
-  hosts: webserver
+  hosts: newly-created
   user: ubuntu
   sudo: yes
   vars_files:


### PR DESCRIPTION
* Updating the add_hosts command in nova to properly add a
  set of hosts that allows plays to be run against only newly
  created servers.

This also breaks out the add host task into a separate role.

@mshmsh5000 @sergii-tkachenko 